### PR TITLE
more detailed "macro status"

### DIFF
--- a/eventMacro/Core.pm
+++ b/eventMacro/Core.pm
@@ -435,12 +435,12 @@ sub iterate_macro {
 		return;
 	}
 	return if $self->is_paused();
-	my %tmptime = $self->{Macro_Runner}->timeout;
+	my $tmptime = $self->{Macro_Runner}->timeout;
 	unless ($self->{Macro_Runner}->registered || $self->{Macro_Runner}->overrideAI) {
-		if (timeOut(\%tmptime)) {$self->{Macro_Runner}->register}
+		if (timeOut($tmptime)) {$self->{Macro_Runner}->register}
 		else {return}
 	}
-	if (timeOut(\%tmptime) && ai_isIdle()) {
+	if (timeOut($tmptime) && ai_isIdle()) {
 		do {
 			last unless processCmd $self->{Macro_Runner}->next;
 			Plugins::callHook ('macro/call_macro/process');

--- a/eventMacro/Runner.pm
+++ b/eventMacro/Runner.pm
@@ -20,7 +20,8 @@ use eventMacro::Automacro;
 
 our ($rev) = q$Revision: 6782 $ =~ /(\d+)/;
 
-my %macro;
+our %macro;
+our @EXPORT_OK = qw( %macro );
 
 # constructor
 sub new {
@@ -104,7 +105,7 @@ sub setMacro_delay {
 # sets or gets timeout for next command
 sub timeout {
 	if (defined $_[1]) {$_[0]->{timeout} = $_[1]}
-	return (time => $_[0]->{time}, timeout => $_[0]->{timeout})
+	return { time => $_[0]->{time}, timeout => $_[0]->{timeout} };
 }
 
 # sets or gets override AI value
@@ -192,9 +193,9 @@ sub next {
 	if (defined $self->{subcall}) {
 		my $command = $self->{subcall}->next;
 		if (defined $command) {
-			my %tmptime = $self->{subcall}->timeout;
-			$self->{timeout} = $tmptime{timeout};
-			$self->{time} = $tmptime{time};
+			my $tmptime = $self->{subcall}->timeout;
+			$self->{timeout} = $tmptime->{timeout};
+			$self->{time} = $tmptime->{time};
 			if ($self->{subcall}->finished) {
 				if ($self->{subcall}->{repeat} == 0) {$self->{finished} = 1}
 				undef $self->{subcall};
@@ -554,7 +555,7 @@ sub next {
 			if (defined $times && $times =~ /\d+/) { $calltimes = $times; }; # do we have a valid repeat value?
 		}
 		
-		$self->{subcall} = new Macro::Script($name, $calltimes, undef, undef, $self->{interruptible});
+		$self->{subcall} = eventMacro::Runner->new($name, $calltimes, undef, undef, $self->{interruptible});
 		
 		unless (defined $self->{subcall}) {
 			$self->{error} = "$errtpl: failed to call script";


### PR DESCRIPTION
Change the way "macro status" is displayed to include the current line being executed and the call stack.

This pull request also fixes a bug which prevented the `call` command from working.

Old:

```
paused: no
macro dizoi1
status: running
delay: 1s
line: 2
override AI: no
finished: no
```

New:

```
macro dizoi1
status: running
paused: no
dizoi1 (line 2) : call dizoi2
  delay=1.5s (Mon Jul 11 12:57:28 2016)
dizoi2 (line 2) : call dizoi3
  delay=1.5s (Mon Jul 11 12:57:28 2016)
dizoi3 (line 2) : call dizoi4
  delay=1.5s (Mon Jul 11 12:57:28 2016)
dizoi4 (line 2) : pause 3
  delay=1.5s (Mon Jul 11 12:57:28 2016)
```
