### PR TITLE
fix macro_delay (support sub-second timing)

### DIFF
--- a/eventMacro/Runner.pm
+++ b/eventMacro/Runner.pm
@@ -6,6 +6,7 @@ use strict;
 require Exporter;
 our @ISA = qw(Exporter);
 
+use Time::HiRes qw( &time );
 use Utils;
 use Globals;
 use AI;


### PR DESCRIPTION
Using `Time::HiRes` lets us time our macros accurately. Without it, `macro_delay` only kinda-sorta works.
