### PR TITLE
Remove unnecessary hook calls

### DIFF
--- a/eventMacro/Core.pm
+++ b/eventMacro/Core.pm
@@ -445,7 +445,6 @@ sub iterate_macro {
 	if (timeOut($tmptime) && ai_isIdle()) {
 		do {
 			last unless processCmd $self->{Macro_Runner}->next;
-			Plugins::callHook ('macro/call_macro/process');
 		} while $self->{Macro_Runner} && !$self->is_paused() && $self->{Macro_Runner}->macro_block;
 		
 =pod

--- a/eventMacro/Utilities.pm
+++ b/eventMacro/Utilities.pm
@@ -477,7 +477,6 @@ sub processCmd {
 					'name' => $eventMacro->{Macro_Runner}->name,
 					'error' => 'Commands::run failed',
 				};
-				Plugins::callHook ('macro/error', $hookArgs);
 				return $hookArgs->{continue} if $hookArgs->{return};
 				
 				error $errorMsg, "macro";
@@ -501,7 +500,6 @@ sub processCmd {
 			'name' => $name,
 			'error' => $error,
 		};
-		Plugins::callHook ('macro/error', $hookArgs);
 		return $hookArgs->{continue} if $hookArgs->{return};
 		
 		error $errorMsg, "macro";


### PR DESCRIPTION
Right now we have no use for this hooks and they are using cpu time,
especially 'Plugins::callHook ('macro/call_macro/process')' which is
called very frequently.
