### PR TITLE
Make automacros checking faster

### DIFF
--- a/eventMacro.pl
+++ b/eventMacro.pl
@@ -216,9 +216,9 @@ sub commandHandler {
 	} elsif ($arg eq 'reset') {
 		if (!defined $params[0]) {
 			foreach my $automacro (@{$eventMacro->{Automacro_List}->getItems()}) {
-				$automacro->enable();
+				$eventMacro->enable_automacro($automacro);
 			}
-			message "[eventMacro] Automacros run-once cleared.\n";
+			message "[eventMacro] All automacros were enabled.\n";
 			return;
 		}
 		for my $automacro_name (@params) {
@@ -226,7 +226,7 @@ sub commandHandler {
 			if (!$automacro) {
 				error "[eventMacro] Automacro '".$automacro_name."' not found.\n"
 			} else {
-				$automacro->enable();
+				$eventMacro->enable_automacro($automacro);
 			}
 		}
 	### parameter: automacro

--- a/eventMacro/Automacro.pm
+++ b/eventMacro/Automacro.pm
@@ -35,7 +35,7 @@ sub parse_and_create_conditions {
 }
 
 sub get_running_status {
-	my ($self, $new_status) = @_;
+	my ($self) = @_;
 	return $self->{running_status};
 }
 

--- a/eventMacro/Automacro.pm
+++ b/eventMacro/Automacro.pm
@@ -19,6 +19,7 @@ sub new {
 	$self->{hooks} = {};
 	$self->{variables} = {};
 	$self->{parameters} = {};
+	$self->{running_status} = 0;
 	$self->set_parameters( $parameters );
 	
 	return $self;
@@ -31,6 +32,21 @@ sub parse_and_create_conditions {
 	if (defined $self->{event_type_condition_index}) {
 		$self->{number_of_false_conditions}--;
 	}
+}
+
+sub get_running_status {
+	my ($self, $new_status) = @_;
+	return $self->{running_status};
+}
+
+sub set_running_status {
+	my ($self, $new_status) = @_;
+	$self->{running_status} = $new_status;
+}
+
+sub get_index {
+	my ($self) = @_;
+	return $self->{listIndex};
 }
 
 sub get_hooks {
@@ -57,14 +73,12 @@ sub disable {
 	my ($self) = @_;
 	$self->{parameters}{disabled} = 1;
 	debug "[eventMacro] Disabling ".$self->get_name()."\n", "eventMacro", 2;
-	return 1;
 }
 
 sub enable {
 	my ($self) = @_;
 	$self->{parameters}{disabled} = 0;
 	debug "[eventMacro] Enabling ".$self->get_name()."\n", "eventMacro", 2;
-	return 1;
 }
 
 sub get_parameter {
@@ -163,6 +177,7 @@ sub check_state_type_condition {
 	} elsif ($pre_check_status == 0 && $condition->is_fulfilled == 1) {
 		$self->{number_of_false_conditions}--;
 	}
+	return $pos_check_status;
 }
 
 sub check_event_type_condition {
@@ -194,7 +209,13 @@ sub is_timed_out {
 	return 0;
 }
 
-sub can_be_run {
+sub can_be_added_to_queue {
+	my ($self) = @_;
+	return 1 if ($self->are_conditions_fulfilled && !$self->is_disabled && !$self->get_running_status && !$self->has_event_type_condition);
+	return 0;
+}
+
+sub can_be_run_from_event {
 	my ($self) = @_;
 	return 1 if ($self->are_conditions_fulfilled && !$self->is_disabled && $self->is_timed_out);
 	return 0;

--- a/eventMacro/Core.pm
+++ b/eventMacro/Core.pm
@@ -28,13 +28,8 @@ sub new {
 	$self->{Condition_Modules_Loaded} = {};
 	$self->create_automacro_list($parse_result->{automacros});
 	
-	
-	$self->{Index_Priority_List} = [];
-	$self->create_priority_list();
-	
 	$self->{AI_pre_Hook_Handle} = undef;
 	$self->set_automacro_checking_status();
-	
 	
 	$self->{Event_Related_Variables} = {};
 	$self->{Event_Related_Hooks} = {};
@@ -45,6 +40,13 @@ sub new {
 	$self->{Macro_Runner} = undef;
 	
 	$self->{Variable_List_Hash} = {};
+	
+	$self->{number_of_triggered_automacros} = 0;
+	
+	#must add a sorting algorithm here later
+	$self->{triggered_prioritized_automacros_index_list} = [];
+	
+	$self->{automacro_index_to_queue_index} = {};
 	
 	if ($char && $net && $net->getState() == Network::IN_GAME) {
 		$self->check_all_conditions();
@@ -106,16 +108,6 @@ sub set_automacro_checking_status {
 sub get_automacro_checking_status {
 	my ($self) = @_;
 	return $self->{Automacros_Checking_Status};
-}
-
-sub create_priority_list {
-	my ($self) = @_;
-	
-	my %priority_hash;
-	foreach my $automacro (@{$self->{Automacro_List}->getItems()}) {
-		$priority_hash{$automacro->{listIndex}} = $automacro->get_parameter('priority');
-	}
-	@{$self->{Index_Priority_List}} = sort { $priority_hash{$a} <=> $priority_hash{$b} } keys %priority_hash;
 }
 
 sub create_macro_list {
@@ -372,6 +364,75 @@ sub exists_var {
 	return (exists $self->{Variable_List_Hash}{$variable_name});
 }
 
+sub add_to_triggered_prioritized_automacros_index_list {
+	my ($self, $automacro) = @_;
+	my $priority = $automacro->get_parameter('priority');
+	my $index = $automacro->get_index;
+	
+	push( @{ $self->{triggered_prioritized_automacros_index_list} }, { index => $index, priority => $priority } );
+	
+	my $size = scalar @{ $self->{triggered_prioritized_automacros_index_list} };
+	
+	$self->{automacro_index_to_queue_index}{$index} = $size - 1;
+	
+	my $new_index;
+	
+	if ( $size == 1 ) {
+		$new_index = 0;
+	} else {
+		my $check_index = -1;
+		my $current = @{ $self->{triggered_prioritized_automacros_index_list} }[$check_index];
+		my $next = @{ $self->{triggered_prioritized_automacros_index_list} }[$check_index-1];
+		while ($next->{priority} > $current->{priority}) {
+			@{ $self->{triggered_prioritized_automacros_index_list} }[$check_index] = $next;
+			$self->{automacro_index_to_queue_index}{$next->{index}} = $size + $check_index;
+			
+			@{ $self->{triggered_prioritized_automacros_index_list} }[$check_index-1] = $current;
+			$self->{automacro_index_to_queue_index}{$current->{index}} = $size + $check_index - 1;
+			
+			last if ($size + $check_index == 0);
+			
+		} continue {
+		
+			$check_index--;
+			$current = @{ $self->{triggered_prioritized_automacros_index_list} }[$check_index];
+			$next = @{ $self->{triggered_prioritized_automacros_index_list} }[$check_index-1];
+			
+		}
+		
+		$new_index = ($size + $check_index);
+	}
+	
+	debug "[eventMacro] Automacro '".$automacro->get_name()."' met it's conditions. Adding it to running queue in position '".$new_index."'.\n", "eventMacro";
+	
+	return $new_index;
+}
+
+sub remove_from_triggered_prioritized_automacros_index_list {
+	my ($self, $automacro) = @_;
+	my $priority = $automacro->get_parameter('priority');
+	my $index = $automacro->get_index;
+	
+	my $queue_index = $self->{automacro_index_to_queue_index}{$index};
+	
+	splice (@{ $self->{triggered_prioritized_automacros_index_list} }, $queue_index, 1);
+	
+	my $size = scalar @{ $self->{triggered_prioritized_automacros_index_list} };
+	
+	unless ($size == 0) {
+		my $current = $queue_index;
+		foreach my $member (@{ $self->{triggered_prioritized_automacros_index_list} }[$queue_index..($size-1)]) {
+			$self->{automacro_index_to_queue_index}{$member->{index}} = $current;
+		} continue {
+			$current++;
+		}
+	}
+	
+	debug "[eventMacro] Automacro '".$automacro->get_name()."' no longer meets it's conditions. Removing it from running queue from position '".$queue_index."'.\n", "eventMacro";
+	
+	return $queue_index;
+}
+
 sub manage_event_callbacks {
 	my $self = shift;
 	my $callback_type = shift;
@@ -407,7 +468,22 @@ sub manage_event_callbacks {
 				next;
 			} else {
 				debug "[eventMacro] Variable value will be updated in condition of state type in automacro '".$automacro->get_name()."'.\n", "eventMacro", 3 if ($callback_type eq 'variable');
-				$automacro->check_state_type_condition($condition_index, $callback_type, $callback_name, $args);
+				
+				my $result = $automacro->check_state_type_condition($condition_index, $callback_type, $callback_name, $args);
+				
+				#add to running queue
+				if (!$result && $automacro->get_running_status) {
+					my $index = $self->remove_from_triggered_prioritized_automacros_index_list($automacro);
+					$self->{number_of_triggered_automacros}--;
+					$automacro->set_running_status(0);
+				
+				#remove from running queue
+				} elsif ($result && $automacro->can_be_added_to_queue) {
+					my $index = $self->add_to_triggered_prioritized_automacros_index_list($automacro);
+					$self->{number_of_triggered_automacros}++;
+					$automacro->set_running_status(1);
+					
+				}
 			}
 		}
 		
@@ -417,7 +493,7 @@ sub manage_event_callbacks {
 				debug "[eventMacro] Variable value will be updated in condition of event type in automacro '".$automacro->get_name()."'.\n", "eventMacro", 3;
 				$automacro->check_event_type_condition($callback_type, $callback_name, $args);
 				
-			} elsif (($self->get_automacro_checking_status == CHECKING_AUTOMACROS || $self->get_automacro_checking_status == CHECKING_FORCED_BY_USER) && $automacro->can_be_run) {
+			} elsif (($self->get_automacro_checking_status == CHECKING_AUTOMACROS || $self->get_automacro_checking_status == CHECKING_FORCED_BY_USER) && $automacro->can_be_run_from_event) {
 				debug "[eventMacro] Condition of event type will be checked in automacro '".$automacro->get_name()."'.\n", "eventMacro", 3;
 				
 				if ($automacro->check_event_type_condition($callback_type, $callback_name, $args)) {
@@ -504,24 +580,33 @@ sub manage_dynamic_hook_add_and_delete {
 sub AI_pre_checker {
 	my ($self) = @_;
 	
-	#maybe we should have a list of fulfilled automacros instead of checking for it each AI_pre cycle
-	#would using a binary heap to extract and add members to above said list benefit cpu use?
+	foreach my $array_member (@{$self->{triggered_prioritized_automacros_index_list}}) {
 	
-	#should AI_pre only be hooked when we are sure there are automacros with conditions fulfilled?
-	
-	foreach my $index (@{$self->{Index_Priority_List}}) {
-	
-		my $automacro = $self->{Automacro_List}->get($index);
+		my $automacro = $self->{Automacro_List}->get($array_member->{index});
 		
-		next if $automacro->has_event_type_condition();
-		
-		next unless $automacro->can_be_run;
+		next unless $automacro->is_timed_out;
 		
 		message "[eventMacro] Conditions met for automacro '".$automacro->get_name()."', calling macro '".$automacro->get_parameter('call')."'\n", "system";
 		
 		$self->call_macro($automacro);
 		
 		return;
+	}
+}
+
+sub disable_automacro {
+	my ($self, $automacro) = @_;
+	$automacro->disable;
+	if ($automacro->get_running_status) {
+		$self->remove_from_triggered_prioritized_automacros_index_list($automacro);
+	}
+}
+
+sub enable_automacro {
+	my ($self, $automacro) = @_;
+	$automacro->enable;
+	if ($automacro->can_be_added_to_queue) {
+		$self->add_to_triggered_prioritized_automacros_index_list($automacro);
 	}
 }
 
@@ -533,7 +618,9 @@ sub call_macro {
 	}
 	
 	$automacro->set_timeout_time(time);
-	$automacro->disable() if $automacro->get_parameter('run-once');
+	if ($automacro->get_parameter('run-once')) {
+		$self->disable_automacro($automacro);
+	}
 	
 	my $new_variables = $automacro->get_new_macro_variables;
 	

--- a/eventMacro/Core.pm
+++ b/eventMacro/Core.pm
@@ -328,9 +328,10 @@ sub check_all_conditions {
 			next if ($condition->condition_type == EVENT_TYPE);
 			debug "[eventMacro] Checking condition of index '".$condition->{listIndex}."' in automacro '".$automacro->get_name."'\n", "eventMacro", 2;
 			$automacro->check_state_type_condition($condition->{listIndex}, 'recheck')
-			
 		}
-		
+		if ($automacro->can_be_added_to_queue) {
+			$self->add_to_triggered_prioritized_automacros_index_list($automacro);
+		}
 	}
 }
 

--- a/eventMacro/Runner.pm
+++ b/eventMacro/Runner.pm
@@ -1220,9 +1220,9 @@ sub parse_release_and_lock {
 	my $automacro = $eventMacro->{Automacro_List}->getByName($parsed_automacro_name);
 	
 	if ($type == 1) {
-		$automacro->disable();
+		$eventMacro->disable_automacro($automacro);
 	} else {
-		$automacro->enable();
+		$eventMacro->enable_automacro($automacro);
 	}
 	
 	$self->timeout(0);


### PR DESCRIPTION
Now only automacros with met conditions will be checked on running time on AI_pre hook, and only their timeout will be checked, no more checking conditions during AI_pre.