### PR TITLE
avoid crash when pausing before login is complete

### DIFF
--- a/eventMacro/Condition/InLockMap.pm
+++ b/eventMacro/Condition/InLockMap.pm
@@ -29,7 +29,7 @@ sub _parse_syntax {
 sub validate_condition {
 	my ( $self, $callback_type, $callback_name, $args ) = @_;
 
-	$self->{lastMap} = $field->baseName;
+	$self->{lastMap} = $field ? $field->baseName : '';
 	$self->{lastLockMap} ||= '';
 
 	if ( $callback_type eq 'hook' && $callback_name eq 'configModify' && $args->{key} eq 'lockMap' ) {


### PR DESCRIPTION
Fix a crash that happens when a config option is changed (which triggers the `configModify` hook) before login is complete (which means `$field` isn't defined yet).

```
automacro auto {
  timeout 2
  InLockMap 1
  call {
    log Execution will never reach this point.
  }
}

# Before login is complete, run this on the console:
conf lockMap prontera
```