### PR TITLE
resolve special variables when they are used

### DIFF
--- a/eventMacro/Core.pm
+++ b/eventMacro/Core.pm
@@ -738,6 +738,36 @@ sub defined_var {
 # Scalars
 sub get_scalar_var {
 	my ($self, $variable_name) = @_;
+
+	# Handle special variables.
+	if ( substr( $variable_name, 0, 1 ) eq '.' ) {
+
+		# Time-related variables.
+		if    ( $variable_name eq '.time' )     { return time; }
+		elsif ( $variable_name eq '.datetime' ) { return scalar localtime; }
+		elsif ( $variable_name eq '.second' )   { return ( localtime() )[0]; }
+		elsif ( $variable_name eq '.minute' )   { return ( localtime() )[1]; }
+		elsif ( $variable_name eq '.hour' )     { return ( localtime() )[2]; }
+
+		# Field-related variables.
+		elsif ( $variable_name eq '.map' ) { return $field ? $field->baseName : ''; }
+
+		# Character-related variables.
+		elsif ( $variable_name eq '.pos' ) { return $char ? sprintf( '%d %d', @{ calcPosition( $char ) }{ 'x', 'y' } ) : ''; }
+		elsif ( $variable_name eq '.hp' )        { return $char && $char->{hp}         || 0; }
+		elsif ( $variable_name eq '.sp' )        { return $char && $char->{sp}         || 0; }
+		elsif ( $variable_name eq '.lvl' )       { return $char && $char->{lv}         || 0; }
+		elsif ( $variable_name eq '.joblvl' )    { return $char && $char->{lv_job}     || 0; }
+		elsif ( $variable_name eq '.spirits' )   { return $char && $char->{spirits}    || 0; }
+		elsif ( $variable_name eq '.zeny' )      { return $char && $char->{zeny}       || 0; }
+		elsif ( $variable_name eq '.weight' )    { return $char && $char->{weight}     || 0; }
+		elsif ( $variable_name eq '.maxweight' ) { return $char && $char->{weight_max} || 0; }
+		elsif ( $variable_name eq '.status' ) {
+			return '' if !$char;
+			return join ',', sort( ( $char->{muted} ? 'muted' : () ), ( $char->{dead} ? 'dead' : () ), map { $statusName{$_} || $_ } keys %{ $char->{statuses} } );
+		}
+	}
+
 	return $self->{Scalar_Variable_List_Hash}{$variable_name} if (exists $self->{Scalar_Variable_List_Hash}{$variable_name});
 	return undef;
 }

--- a/eventMacro/Runner.pm
+++ b/eventMacro/Runner.pm
@@ -16,7 +16,7 @@ use List::Util qw(max min sum);
 use eventMacro::Data;
 use eventMacro::Core;
 use eventMacro::FileParser qw(isNewCommandBlock);
-use eventMacro::Utilities qw(cmpr refreshGlobal getnpcID getItemIDs getItemPrice getStorageIDs getInventoryIDs
+use eventMacro::Utilities qw(cmpr getnpcID getItemIDs getItemPrice getStorageIDs getInventoryIDs
 	getPlayerID getMonsterID getVenderID getRandom getRandomRange getInventoryAmount getCartAmount getShopAmount
 	getStorageAmount getVendAmount getConfig getWord q4rx q4rx2 getArgFromList getListLenght find_variable get_key_or_index);
 use eventMacro::Automacro;
@@ -1729,9 +1729,6 @@ sub parse_command {
 	return "" unless defined $command;
 	my ($keyword, $inside_brackets, $parsed, $result, $sub, $val);
 
-	# refresh global vars only once per command line
-	refreshGlobal();
-	
 	while (($keyword, $inside_brackets) = parse_keywords($command)) {
 		$result = "_%_";
 		

--- a/eventMacro/Utilities.pm
+++ b/eventMacro/Utilities.pm
@@ -5,7 +5,7 @@ use strict;
 
 require Exporter;
 our @ISA = qw(Exporter);
-our @EXPORT_OK = qw(q4rx q4rx2 between cmpr match getArgs refreshGlobal getnpcID getPlayerID
+our @EXPORT_OK = qw(q4rx q4rx2 between cmpr match getArgs getnpcID getPlayerID
 	getMonsterID getVenderID getItemIDs getItemPrice getInventoryIDs getStorageIDs getSoldOut getInventoryAmount
 	getCartAmount getShopAmount getStorageAmount getVendAmount getRandom getRandomRange getConfig
 	getWord call_macro getArgFromList getListLenght sameParty processCmd find_variable get_key_or_index getInventoryAmountbyID
@@ -186,38 +186,6 @@ sub getConfig {
 		};
 	};
 	return (defined $::config{$arg1})?$::config{$arg1}:"";
-}
-
-# sets and/or refreshes global variables
-sub refreshGlobal {
-	my $var = $_[0];
-
-	$eventMacro->set_scalar_var(".time", time, 0);
-	$eventMacro->set_scalar_var(".datetime", scalar localtime, 0);
-	my ($sec, $min, $hour) = localtime;
-	$eventMacro->set_scalar_var(".second", $sec, 0);
-	$eventMacro->set_scalar_var(".minute", $min, 0);
-	$eventMacro->set_scalar_var(".hour", $hour, 0);
-	
-	return unless $net && $net->getState == Network::IN_GAME;
-	
-	$eventMacro->set_scalar_var(".map", (defined $field)?$field->baseName:"undef", 0);
-	my $pos = calcPosition($char); 
-	$eventMacro->set_scalar_var(".pos", sprintf("%d %d", $pos->{x}, $pos->{y}), 0);
-	
-	$eventMacro->set_scalar_var(".hp", $char->{hp}, 0);
-	$eventMacro->set_scalar_var(".sp", $char->{sp}, 0);
-	$eventMacro->set_scalar_var(".lvl", $char->{lv}, 0);
-	$eventMacro->set_scalar_var(".joblvl", $char->{lv_job}, 0);
-	$eventMacro->set_scalar_var(".spirits", ($char->{spirits} or 0), 0);
-	$eventMacro->set_scalar_var(".zeny", $char->{zeny}, 0);
-	$eventMacro->set_scalar_var(".weight", $char->{weight}, 0);
-	$eventMacro->set_scalar_var(".maxweight", $char->{weight_max}, 0);
-	$eventMacro->set_scalar_var('.status', (join ',',
-		('muted')x!!$char->{muted},
-		('dead')x!!$char->{dead},
-		map { $statusName{$_} || $_ } keys %{$char->{statuses}}
-	) || 'none', 0);
 }
 
 # get NPC array index


### PR DESCRIPTION
- [ ] Product Review (is this a good idea?)
- [x] QA Review (does it work?)
- [ ] Code Review (is the code well written?)

Currently, `eventMacro` updates special variables in `parse_command`, which is triggered for many but not all macro commands. Most lines which include such commands do not use the special variables, however, so we should resolve them only when needed.

This change allows us to add more special variables without increasing the cost of commands which do not use any special variables.

As an additional enhancement, the resolution of special variables could be done via a hash with coderefs to make resolving them a constant-time operation instead of linear-time. I didn't do that because I believe the code is clearer this way and we don't (currently) have a lot of special variables.

This was tested with the following eventMacros:
```
macro test {
  call test2
}

macro test2 {
  log map       : $.map
  log pos       : $.pos
  log time      : $.time
  log datetime  : $.datetime
  log hour      : $.hour
  log minute    : $.minute
  log second    : $.second
  log hp        : $.hp
  log sp        : $.sp
  log lvl       : $.lvl
  log joblvl    : $.joblvl
  log spirits   : $.spirits
  log zeny      : $.zeny
  log status    : $.status
  log param1    : $.param1
  log param2    : $.param2
  log caller    : $.caller
  log weight    : $.weight
  log maxweight : $.maxweight
}
```

... and the following command line:
```
eventMacro test -- a b c
```
